### PR TITLE
Add root homepage endpoint

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,2 @@
+<section class="w-full">
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "home#index"
 end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe "Home", type: :request do
+  describe "GET /" do
+    it "returns a successful HTML response" do
+      get root_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/html")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add the Rails root route for 
- render a conventional  view
- add a request spec covering 200 OK and HTML content type

## Verification
- bin/rspec spec/requests/home_spec.rb
- bin/rspec
- RUBOCOP_CACHE_ROOT=/tmp/rubocop-cache bin/rubocop
- manual GET http://127.0.0.1:3000/

Closes #2