### PR TITLE
Add repository registration baseline

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -1,0 +1,7 @@
+class RepositoriesController < ApplicationController
+  def index
+    repositories = Repository.order(:provider, :namespace_path, :name)
+
+    render locals: { repositories: }
+  end
+end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,0 +1,4 @@
+class Repository < ApplicationRecord
+  validates :provider, :namespace_path, :name, :default_base_ref, presence: true
+  validates :name, uniqueness: { scope: %i[provider namespace_path] }
+end

--- a/app/views/repositories/index.html.erb
+++ b/app/views/repositories/index.html.erb
@@ -1,0 +1,29 @@
+<section class="space-y-6">
+  <header>
+    <h1 class="text-2xl font-semibold">Repositories</h1>
+  </header>
+
+  <% if repositories.empty? %>
+    <p>No repositories yet</p>
+  <% else %>
+    <ul class="space-y-4">
+      <% repositories.each do |repository| %>
+        <li class="rounded border p-4">
+          <dl class="grid gap-1 sm:grid-cols-[auto_1fr] sm:gap-x-3">
+            <dt class="font-medium">Provider</dt>
+            <dd><%= repository.provider %></dd>
+
+            <dt class="font-medium">Namespace path</dt>
+            <dd><%= repository.namespace_path %></dd>
+
+            <dt class="font-medium">Name</dt>
+            <dd><%= repository.name %></dd>
+
+            <dt class="font-medium">Default base ref</dt>
+            <dd><%= repository.default_base_ref %></dd>
+          </dl>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "home#index"
+
+  resources :repositories, only: %i[index]
 end

--- a/db/migrate/20260409000000_create_repositories.rb
+++ b/db/migrate/20260409000000_create_repositories.rb
@@ -1,0 +1,14 @@
+class CreateRepositories < ActiveRecord::Migration[8.1]
+  def change
+    create_table :repositories do |t|
+      t.string :provider, null: false
+      t.string :namespace_path, null: false
+      t.string :name, null: false
+      t.string :default_base_ref, null: false, default: "main"
+
+      t.timestamps
+    end
+
+    add_index :repositories, %i[provider namespace_path name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 2026_04_09_000000) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
+  create_table "repositories", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "default_base_ref", default: "main", null: false
+    t.string "name", null: false
+    t.string "namespace_path", null: false
+    t.string "provider", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "namespace_path", "name"], name: "index_repositories_on_provider_and_namespace_path_and_name", unique: true
+  end
+end

--- a/memory-bank/features/004/brief.md
+++ b/memory-bank/features/004/brief.md
@@ -1,0 +1,23 @@
+---
+title: "Loki lacks a way for users to register repositories"
+issue_link: "https://github.com/bsboris/loki/issues/4"
+status: active
+---
+
+## Problem
+
+Users currently cannot create or store a repository record in Loki, so zero repositories can be registered in the system. Without a stored repository record, a user cannot begin repository setup or create a translation workspace tied to a repository.
+
+## Stakeholder
+
+Primary stakeholder: app users who need to register a repository before creating a translation workspace.
+
+Secondary stakeholder: product developers who are blocked on repository-dependent MVP features.
+
+## Context
+
+This task is important now because repository registration is the prerequisite for upcoming MVP flows: GitHub integration, repository configuration, and workspace setup. Repositories are a core domain object in Loki, and these dependent flows cannot proceed until repository records exist in the system.
+
+## Desired outcome
+
+Users can register and view repository records in Loki, and those records exist in the system for use by the next MVP steps: GitHub integration, repository configuration, and workspace creation.

--- a/memory-bank/features/004/plan.md
+++ b/memory-bank/features/004/plan.md
@@ -1,0 +1,72 @@
+---
+title: "Repository Registration Implementation Plan"
+spec_link: "memory-bank/features/004/spec.md"
+status: draft
+---
+
+## Overview
+
+Implement the minimum Rails support for storing repositories and rendering a server-side HTML index page at `GET /repositories`, with model and request coverage aligned to the feature spec.
+
+## Plan
+
+1. Add persistence
+   - Create `db/migrate/*_create_repositories.rb` for `repositories` with:
+     - `provider`
+     - `namespace_path`
+     - `name`
+     - `default_base_ref`
+     - timestamps
+   - Enforce `null: false` on all repository attributes.
+   - Set the database default for `default_base_ref` to `"main"`.
+   - Add a unique composite index on `provider`, `namespace_path`, and `name`.
+   - Run migrations so `db/schema.rb` is generated or updated with the new table and index.
+
+2. Add the domain model
+   - Create `app/models/repository.rb` with `Repository < ApplicationRecord`.
+   - Add presence validations for `provider`, `namespace_path`, `name`, and `default_base_ref`.
+   - Add a uniqueness validation for `name`, scoped to `provider` and `namespace_path`.
+   - Keep `app/models/repository.rb` free of provider-specific behavior, sync logic, and workspace logic.
+
+3. Add the repository index endpoint
+   - Update `config/routes.rb` to expose only `GET /repositories`, routed to `RepositoriesController#index`.
+   - Create `app/controllers/repositories_controller.rb` with `RepositoriesController#index`.
+   - Load repository records from the database in `index`.
+   - Create `app/views/repositories/index.html.erb`.
+   - Render `No repositories yet` when no records exist.
+   - Render each repository’s `provider`, `namespace_path`, `name`, and `default_base_ref` when records exist.
+   - Do not add any other repository routes, forms, actions, pagination, filtering, sorting controls, or JavaScript-dependent behavior.
+
+4. Add automated verification
+   - Create `spec/models/repository_spec.rb` for:
+     - required attributes
+     - scoped uniqueness for `provider + namespace_path + name`
+     - required `default_base_ref`
+     - default `default_base_ref` of `"main"` when omitted on create
+   - Create `spec/requests/repositories_spec.rb` for:
+     - `GET /repositories` returns `200 OK`
+     - response media type is HTML
+     - empty state renders `No repositories yet`
+     - persisted repository data renders, including `default_base_ref`
+     - no extra repository routes are added
+   - In `spec/requests/repositories_spec.rb`, make the route constraint explicit by asserting unsupported repository routes are not routable, such as `GET /repositories/new` and `GET /repositories/:id`.
+
+## Expected Files
+
+- `db/migrate/*_create_repositories.rb`
+- `db/schema.rb`
+- `app/models/repository.rb`
+- `app/controllers/repositories_controller.rb`
+- `app/views/repositories/index.html.erb`
+- `spec/models/repository_spec.rb`
+- `spec/requests/repositories_spec.rb`
+- `config/routes.rb`
+
+## Verification
+
+- Run targeted specs:
+  - `bin/rspec spec/models/repository_spec.rb spec/requests/repositories_spec.rb`
+- Run full test suite:
+  - `bin/rspec`
+- Run lint:
+  - `bin/rubocop`

--- a/memory-bank/features/004/spec.md
+++ b/memory-bank/features/004/spec.md
@@ -1,0 +1,128 @@
+---
+title: "Repository Registration Baseline Spec"
+brief_link: "memory-bank/features/004/brief.md"
+status: active
+---
+
+## Goal
+
+Define the minimum implementation needed for Loki to store tracked repositories and present them in a server-rendered Rails HTML index page, so repository records can exist in the system for later setup flows.
+
+## Scope
+
+Included in this feature:
+- Add a `Repository` domain model backed by persistent storage.
+- Add the database structure required to store repository records.
+- Store these repository attributes:
+  - `provider`
+  - `namespace_path`
+  - `name`
+  - `default_base_ref`
+- Enforce repository identity by the combination of `provider`, `namespace_path`, and `name`.
+- Add the `GET /repositories` HTML endpoint.
+- Render an index page that shows persisted repository records.
+- Add automated tests for the model constraints and the repository index endpoint.
+
+Not included in this feature:
+- Repository creation UI or create endpoint.
+- Repository show, edit, update, or delete UI/endpoints.
+- GitHub API integration, provider syncing, or repository import flows.
+- Validation against a remote provider.
+- Workspace creation, repository configuration, authentication, or authorization.
+- JSON API support.
+
+Affected modules:
+- Repository persistence (`repositories` table and `Repository` model)
+- Repository index web interface (`GET /repositories`, controller action, and HTML view)
+- Automated verification (model and request specs)
+
+## Invariants
+
+- Repository identity is uniquely defined by the combination of `provider`, `namespace_path`, and `name`.
+- `provider`, `namespace_path`, `name`, and `default_base_ref` are always required at both the model and database layers.
+- `default_base_ref` defaults to `"main"` when a repository record is created without an explicit value.
+- This feature is read-only over HTTP. It adds only `GET /repositories` and no other repository routes.
+- This feature does not perform provider API calls, repository syncing, workspace logic, authentication, or authorization.
+
+## Requirements
+
+1. Persistence
+   - Add a `repositories` table.
+   - The table must store:
+     - `provider`
+     - `namespace_path`
+     - `name`
+     - `default_base_ref`
+     - Rails-managed timestamps
+   - `provider`, `namespace_path`, and `name` must be required at the database level.
+   - `default_base_ref` must be required at the database level and must default to `"main"`.
+   - The database must enforce uniqueness for the composite key `provider + namespace_path + name`.
+
+2. Repository model
+   - Implement a `Repository` model inheriting from `ApplicationRecord`.
+   - The model must validate presence of:
+     - `provider`
+     - `namespace_path`
+     - `name`
+     - `default_base_ref`
+   - The model must validate uniqueness of `name` scoped to `provider` and `namespace_path`.
+   - The model must not include provider-specific behavior, network access, sync logic, or workspace behavior in this feature.
+
+3. Routing and controller
+   - The route must expose `GET /repositories`.
+   - The route must resolve to `RepositoriesController#index`.
+   - Implement `RepositoriesController#index`.
+   - `RepositoriesController#index` must load repository records from the database and render `app/views/repositories/index.html.erb`.
+   - No other `repositories` routes may be added in this feature.
+
+4. HTML index page
+   - Render a dedicated ERB template at `app/views/repositories/index.html.erb`.
+   - The page must return `200 OK` with HTML content type.
+   - Loading state: not applicable. This page is rendered synchronously on the server and does not implement a client-side loading state.
+   - Empty state: when there are zero repository records, the page must render the text `No repositories yet`.
+   - Success state: for each persisted repository record, the page must display:
+     - `provider`
+     - `namespace_path`
+     - `name`
+     - `default_base_ref`
+   - Error state: no custom application-level error UI or error handling is implemented in this feature.
+   - Unhandled exception behavior is out of scope for this feature and is not part of the acceptance criteria.
+   - The page does not need pagination, filtering, search, sorting controls, or action buttons.
+
+5. Automated verification
+   - Add model specs that cover:
+     - required attributes
+     - composite uniqueness for `provider + namespace_path + name`
+     - `default_base_ref` is required
+     - `default_base_ref` defaults to `"main"` when a record is created without an explicit value
+   - Add a request spec for `GET /repositories`.
+   - The request spec must assert:
+     - response status is `200 OK`
+     - response content type is HTML
+     - the page renders `No repositories yet` with no records
+     - the page renders persisted repository data
+     - the page renders `default_base_ref` for each persisted repository
+     - no other `repositories` routes are present
+   - The specs must run under the existing RSpec suite without adding dependencies.
+
+## Acceptance Criteria
+
+1. A `repositories` table exists with columns for `provider`, `namespace_path`, `name`, `default_base_ref`, and timestamps.
+2. The database rejects duplicate repository records with the same `provider`, `namespace_path`, and `name`.
+3. A `Repository` model exists and validates presence of `provider`, `namespace_path`, `name`, and `default_base_ref`.
+4. `default_base_ref` is not nullable and defaults to `"main"`.
+5. `GET /repositories` is routed to `RepositoriesController#index`.
+6. A request to `GET /repositories` returns `200 OK`.
+7. A request to `GET /repositories` returns an HTML response.
+8. When the database contains zero repository records, the repository index page includes the text `No repositories yet`.
+9. The repository index page displays persisted repository records, including `provider`, `namespace_path`, `name`, and `default_base_ref`.
+10. Only `GET /repositories` is added for repositories. No create, show, edit, update, destroy, import, sync, or workspace routes or behavior are implemented as part of this feature.
+
+## Restrictions
+
+- Use standard Rails conventions for the model, migration, route, controller, view, and RSpec coverage.
+- Do not add new gems, frontend frameworks, service objects, or custom abstractions for this feature.
+- Keep the feature server-rendered with standard Rails HTML views.
+- Do not add JSON endpoints, Hotwire flows, JavaScript-dependent interactions, or provider API integration.
+- Do not add repository creation forms or any non-index repository screens.
+- Do not implement soft delete. If repository deletion is introduced outside this spec in later work, it should be hard delete rather than soft delete.

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe Repository, type: :model do
+  describe "validations" do
+    it "requires provider, namespace_path, name, and default_base_ref" do
+      repository = described_class.new(
+        provider: nil,
+        namespace_path: nil,
+        name: nil,
+        default_base_ref: nil
+      )
+
+      expect(repository).not_to be_valid
+      expect(repository.errors[:provider]).to include("can't be blank")
+      expect(repository.errors[:namespace_path]).to include("can't be blank")
+      expect(repository.errors[:name]).to include("can't be blank")
+      expect(repository.errors[:default_base_ref]).to include("can't be blank")
+    end
+
+    it "validates uniqueness of name scoped to provider and namespace_path" do
+      described_class.create!(
+        provider: "github",
+        namespace_path: "acme/platform",
+        name: "loki",
+        default_base_ref: "main"
+      )
+
+      duplicate = described_class.new(
+        provider: "github",
+        namespace_path: "acme/platform",
+        name: "loki",
+        default_base_ref: "develop"
+      )
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:name]).to include("has already been taken")
+    end
+
+    it "allows the same name under a different provider or namespace_path" do
+      described_class.create!(
+        provider: "github",
+        namespace_path: "acme/platform",
+        name: "loki",
+        default_base_ref: "main"
+      )
+
+      other_provider = described_class.new(
+        provider: "gitlab",
+        namespace_path: "acme/platform",
+        name: "loki",
+        default_base_ref: "main"
+      )
+      other_namespace = described_class.new(
+        provider: "github",
+        namespace_path: "acme/infra",
+        name: "loki",
+        default_base_ref: "main"
+      )
+
+      expect(other_provider).to be_valid
+      expect(other_namespace).to be_valid
+    end
+  end
+
+  describe "defaults" do
+    it "defaults default_base_ref to main when omitted on create" do
+      repository = described_class.create!(
+        provider: "github",
+        namespace_path: "acme/platform",
+        name: "loki"
+      )
+
+      expect(repository.reload.default_base_ref).to eq("main")
+    end
+  end
+
+  describe "database constraints" do
+    it "enforces unique provider, namespace_path, and name at the database level" do
+      described_class.create!(
+        provider: "github",
+        namespace_path: "acme/platform",
+        name: "loki",
+        default_base_ref: "main"
+      )
+
+      expect {
+        described_class.insert!({
+          provider: "github",
+          namespace_path: "acme/platform",
+          name: "loki",
+          default_base_ref: "main",
+          created_at: Time.current,
+          updated_at: Time.current
+        })
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+end

--- a/spec/requests/repositories_spec.rb
+++ b/spec/requests/repositories_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Repositories", type: :request do
+  describe "GET /repositories" do
+    it "returns a successful HTML response with the empty state" do
+      get "/repositories"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/html")
+      expect(response.body).to include("No repositories yet")
+    end
+
+    it "renders persisted repository data including default_base_ref" do
+      Repository.create!(
+        provider: "github",
+        namespace_path: "acme/platform",
+        name: "loki",
+        default_base_ref: "main"
+      )
+      Repository.create!(
+        provider: "gitlab",
+        namespace_path: "acme/tools",
+        name: "atlas",
+        default_base_ref: "develop"
+      )
+
+      get "/repositories"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("github", "acme/platform", "loki", "main")
+      expect(response.body).to include("gitlab", "acme/tools", "atlas", "develop")
+    end
+
+    it "routes to repositories#index" do
+      route = Rails.application.routes.recognize_path("/repositories", method: :get)
+
+      expect(route).to include(controller: "repositories", action: "index")
+    end
+
+    it "does not add other repository routes" do
+      expect {
+        Rails.application.routes.recognize_path("/repositories/new", method: :get)
+      }.to raise_error(ActionController::RoutingError)
+
+      expect {
+        Rails.application.routes.recognize_path("/repositories/1", method: :get)
+      }.to raise_error(ActionController::RoutingError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add repository persistence, model validation, and a read-only HTML index at 
- add model and request specs covering defaults, uniqueness, rendering, and route constraints
- include the feature memory-bank brief, spec, and implementation plan in the PR

## Verification
- bin/rails db:migrate
- bin/rspec spec/models/repository_spec.rb spec/requests/repositories_spec.rb
- bin/rspec
- bin/rubocop

Closes #4