### PR TITLE
Add daisyUI styling system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@
 !/log/.keep
 /tmp/*
 !/tmp/.keep
+/node_modules/
 
 .DS_Store

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,5 @@
 @import "tailwindcss";
+@source "../../views/**/*.erb";
+@plugin "daisyui" {
+  themes: light --default;
+}

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,4 +1,8 @@
 class Repository < ApplicationRecord
   validates :provider, :namespace_path, :name, :default_base_ref, presence: true
   validates :name, uniqueness: { scope: %i[provider namespace_path] }
+
+  def qualified_name
+    "#{namespace_path}/#{name}"
+  end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,12 @@
-<section class="w-full">
+<section class="space-y-8 p-8 sm:p-10">
+  <div class="space-y-3">
+    <h1 class="text-4xl font-bold tracking-tight">Loki</h1>
+    <p class="max-w-2xl text-base-content/80">
+      Git-native translation workspace system for YAML-based i18n.
+    </p>
+  </div>
+
+  <%= render "shared/ui/card", title: "Styling system" do %>
+    daisyUI primitives are available for shared UI elements.
+  <% end %>
 </section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="light">
   <head>
     <title><%= content_for(:title) || "Loki" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -23,9 +23,11 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
-    <main class="container mx-auto mt-28 px-5 flex">
-      <%= yield %>
+  <body class="min-h-screen bg-base-200 text-base-content">
+    <main class="mx-auto flex min-h-screen w-full max-w-5xl items-center px-4 py-12 sm:px-6 lg:px-8">
+      <div class="w-full rounded-box border border-base-300 bg-base-100 shadow-xl">
+        <%= yield %>
+      </div>
     </main>
   </body>
 </html>

--- a/app/views/repositories/index.html.erb
+++ b/app/views/repositories/index.html.erb
@@ -1,27 +1,27 @@
-<section class="space-y-6">
-  <header>
-    <h1 class="text-2xl font-semibold">Repositories</h1>
+<section class="space-y-6 p-8 sm:p-10">
+  <header class="space-y-2">
+    <p class="text-sm font-semibold uppercase tracking-[0.2em] text-primary">Catalog</p>
+    <h1 class="text-3xl font-bold tracking-tight">Repositories</h1>
+    <p class="max-w-2xl text-base-content/70">
+      Connected source repositories and their default base branches.
+    </p>
   </header>
 
   <% if repositories.empty? %>
-    <p>No repositories yet</p>
+    <%= render "shared/ui/alert", message: "No repositories yet", variant: :info %>
   <% else %>
-    <ul class="space-y-4">
+    <ul class="grid gap-4">
       <% repositories.each do |repository| %>
-        <li class="rounded border p-4">
-          <dl class="grid gap-1 sm:grid-cols-[auto_1fr] sm:gap-x-3">
-            <dt class="font-medium">Provider</dt>
-            <dd><%= repository.provider %></dd>
+        <li>
+          <%= render "shared/ui/card", title: repository.qualified_name do %>
+            <dl class="grid gap-2 text-sm sm:grid-cols-[auto_1fr] sm:gap-x-4">
+              <dt class="font-semibold text-base-content">Provider</dt>
+              <dd class="text-base-content/75"><%= repository.provider %></dd>
 
-            <dt class="font-medium">Namespace path</dt>
-            <dd><%= repository.namespace_path %></dd>
-
-            <dt class="font-medium">Name</dt>
-            <dd><%= repository.name %></dd>
-
-            <dt class="font-medium">Default base ref</dt>
-            <dd><%= repository.default_base_ref %></dd>
-          </dl>
+              <dt class="font-semibold text-base-content">Default base ref</dt>
+              <dd class="text-base-content/75"><%= repository.default_base_ref %></dd>
+            </dl>
+          <% end %>
         </li>
       <% end %>
     </ul>

--- a/app/views/shared/ui/_alert.html.erb
+++ b/app/views/shared/ui/_alert.html.erb
@@ -1,0 +1,6 @@
+<% alert_classes = ["alert"] %>
+<% alert_classes << "alert-info" if variant == :info %>
+
+<div class="<%= alert_classes.join(" ") %>" role="alert">
+  <span><%= message %></span>
+</div>

--- a/app/views/shared/ui/_card.html.erb
+++ b/app/views/shared/ui/_card.html.erb
@@ -1,0 +1,6 @@
+<article class="card border border-base-300 bg-base-100 shadow-sm">
+  <div class="card-body gap-4">
+    <h2 class="card-title text-xl"><%= title %></h2>
+    <div class="text-base-content/80"><%= yield %></div>
+  </div>
+</article>

--- a/bin/setup
+++ b/bin/setup
@@ -14,6 +14,7 @@ FileUtils.chdir APP_ROOT do
 
   puts "== Installing dependencies =="
   system("bundle check") || system!("bundle install")
+  system("npm install --cache /tmp/loki-npm-cache") || system!("npm install --cache /tmp/loki-npm-cache")
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")

--- a/memory-bank/features/003/brief.md
+++ b/memory-bank/features/003/brief.md
@@ -1,0 +1,23 @@
+---
+title: "Add daisyUI for styling"
+issue_link: "https://github.com/bsboris/loki/issues/62"
+status: active
+---
+
+## Problem
+
+Loki does not yet have a documented, reusable styling system for common UI elements such as buttons, forms, alerts, and layout surfaces. As a result, each new screen that uses these elements requires developers to define their styling locally, and the application has no single standard for how shared elements should appear.
+
+## Stakeholder
+
+Primary stakeholder: product developers building the web UI, who currently need to style repeated interface elements manually for each screen.
+
+Secondary stakeholder: translators and PMs using Loki, who need repeated interface elements such as forms, actions, and status messages to appear and behave consistently across screens.
+
+## Context
+
+This task comes from GitHub issue #62 and is important now because UI work is expanding beyond the initial Rails scaffold. Upcoming MVP screens will require repeated UI patterns across forms, lists, and actions. Without a shared styling standard, each new screen requires new styling decisions for interface elements that should be consistent across the application.
+
+## Desired outcome
+
+Loki has a standard styling vocabulary for common UI elements that can be applied across current and upcoming screens, so repeated interface patterns are implemented consistently throughout the application.

--- a/memory-bank/features/003/plan.md
+++ b/memory-bank/features/003/plan.md
@@ -1,0 +1,61 @@
+---
+title: "daisyUI Styling System Implementation Plan"
+spec_link: "memory-bank/features/003/spec.md"
+status: active
+---
+
+## Overview
+
+Implement the minimum frontend setup and shared ERB primitives needed to establish daisyUI as Loki's default styling system for the existing layout, home page, and repositories index.
+
+## Plan
+
+1. Add frontend styling dependencies
+   - Add `package.json` and `package-lock.json` with the `daisyui` dependency.
+   - Update `bin/setup` to install frontend packages during local bootstrap.
+   - Ignore `node_modules/` in `.gitignore`.
+   - Extend `app/assets/tailwind/application.css` to load daisyUI and define a single default light theme.
+
+2. Add reusable shared UI partials
+   - Create `app/views/shared/ui/_alert.html.erb` with `message:` and `variant:` locals and root class `alert`.
+   - Create `app/views/shared/ui/_card.html.erb` with `title:` and block body content and root class `card`.
+   - Keep the implementation as standard Rails partials without introducing a component framework.
+
+3. Apply the styling system to existing screens
+   - Update `app/views/layouts/application.html.erb` to apply the global daisyUI theme and shared page shell styling.
+   - Update `app/views/home/index.html.erb` to render the required heading, copy, and a shared card.
+   - Update `app/views/repositories/index.html.erb` to render the empty state through the alert partial and repository entries through the card partial.
+   - Add a small presenter-style helper method on `Repository` for the card title without changing domain workflows.
+
+4. Add verification
+   - Extend request specs for the home page and repositories index to assert the required content and shared primitive markup.
+   - Add view specs for the shared alert and card partials.
+   - Add model coverage for the repository display helper.
+
+## Expected Files
+
+- `package.json`
+- `package-lock.json`
+- `.gitignore`
+- `bin/setup`
+- `app/assets/tailwind/application.css`
+- `app/views/shared/ui/_alert.html.erb`
+- `app/views/shared/ui/_card.html.erb`
+- `app/views/layouts/application.html.erb`
+- `app/views/home/index.html.erb`
+- `app/views/repositories/index.html.erb`
+- `app/models/repository.rb`
+- `spec/views/shared/ui/alert_spec.rb`
+- `spec/views/shared/ui/card_spec.rb`
+- `spec/requests/home_spec.rb`
+- `spec/requests/repositories_spec.rb`
+- `spec/models/repository_spec.rb`
+
+## Verification
+
+- Run targeted specs:
+  - `bin/rspec spec/views/shared/ui spec/requests/home_spec.rb spec/requests/repositories_spec.rb spec/models/repository_spec.rb`
+- Run full test suite:
+  - `bin/rspec`
+- Run lint:
+  - `bundle exec rubocop --cache false`

--- a/memory-bank/features/003/spec.md
+++ b/memory-bank/features/003/spec.md
@@ -1,0 +1,162 @@
+---
+title: "daisyUI Styling System Spec"
+brief_link: "memory-bank/features/003/brief.md"
+issue_link: "https://github.com/bsboris/loki/issues/62"
+status: active
+---
+
+## Goal
+
+Define the minimum implementation needed to establish daisyUI as Loki's shared UI styling system on top of Tailwind, so common interface elements can be rendered with a documented, reusable styling vocabulary across existing and upcoming Rails views.
+
+## Scope
+
+Included in this feature:
+- Add daisyUI as a Tailwind plugin in the existing Rails frontend stack.
+- Keep the application server-rendered with Rails views, Tailwind, Propshaft, and Importmaps.
+- Add the frontend build/configuration needed for daisyUI classes to compile into the app stylesheet.
+- Configure one default light theme for the application.
+- Introduce reusable shared view partials for a small set of base UI primitives:
+  - alert
+  - card
+- Apply the shared styling system to existing shared layout surfaces and current pages that already exist in the app:
+  - application layout shell
+  - home page
+  - repositories index page
+- Add automated verification covering successful rendering of the updated pages and the presence of the shared partials.
+
+Not included in this feature:
+- Dark mode or runtime theme switching.
+- A custom branded theme beyond selecting/configuring one default light daisyUI theme.
+- A full component library for every possible UI element.
+- JavaScript UI behaviors beyond what daisyUI styles provide through HTML/CSS.
+- New product flows, new routes, or new domain behavior.
+- ViewComponent, Phlex, or any new component framework.
+- A broad rewrite of all views beyond the existing layout and current pages.
+
+Affected modules:
+- Frontend styling system configuration
+- Shared UI partials
+- Adopted server-rendered pages and their verification
+
+## Invariants
+
+- Tailwind remains the underlying utility framework; daisyUI is added as a plugin layer on top of it.
+- The application remains server-rendered with standard Rails ERB views.
+- Importmaps remain the JavaScript approach; this feature does not introduce a JavaScript bundler for application code.
+- The styling system uses one default light theme only.
+- Shared styling primitives are implemented with Rails partials, not a new component framework.
+- The feature does not add new business logic, persistence, routes, or API endpoints.
+
+## Requirements
+
+1. Frontend integration
+   - Add frontend package/configuration so Tailwind loads the `daisyui` plugin.
+   - Add a `package.json` file and a lockfile for the frontend packages required to load `daisyui`.
+   - Configure Tailwind so daisyUI classes used in Rails templates and shared partials are included in the generated stylesheet.
+   - The existing Rails asset flow must continue to serve the compiled stylesheet through the application layout.
+   - The feature must not replace Tailwind, Propshaft, or Importmaps.
+
+2. Theme configuration
+   - Configure exactly one default light daisyUI theme.
+   - The theme must apply application-wide through the main layout.
+   - No user-facing theme toggle or dark theme behavior is required.
+
+3. Shared styling primitives
+   - Add shared ERB partials for these primitives:
+     - alert
+     - card
+   - The partials must be implemented at these paths:
+     - `app/views/shared/ui/_alert.html.erb`
+     - `app/views/shared/ui/_card.html.erb`
+   - These partials must encapsulate the default daisyUI class vocabulary for each primitive.
+   - The partial API must use Rails locals rather than instance variables.
+   - The partial locals must be explicit and limited to current usage:
+     - alert: `message:`, `variant:`
+     - card: `title:`, `body:`
+   - `variant:` is only required to support `primary` for button and `info` for alert in this feature.
+   - The partials must remain presentation-only and must not contain domain logic.
+
+4. Layout and page adoption
+   - Update the main application layout to use the shared styling system for the primary page shell.
+   - The main layout must apply the selected daisyUI theme on the root `html` element.
+   - Update the current home page so it renders:
+     - one `h1` with the text `Loki`
+     - one paragraph with the text `Git-native translation workspace system for YAML-based i18n.`
+     - one card rendered through the shared card partial with title `Styling system` and body `daisyUI primitives are available for shared UI elements.`
+   - Update the repositories index page to use the shared styling system for:
+     - page container/surface
+     - headings
+     - empty state
+     - repository item presentation
+   - The repositories empty state must render `No repositories yet` through the shared alert partial with alert variant `info`.
+   - Each repository item must render through the shared card partial.
+   - Existing page behavior and route structure must remain unchanged.
+   - The repository index must continue to render all repository attributes already required by feature 002.
+
+5. Documentation in code
+   - Any helper stylesheet or config file added for daisyUI integration must be specific to this styling system only.
+   - This feature does not require additional prose documentation outside the codebase memory-bank spec itself.
+
+6. Automated verification
+   - Add request specs for the existing pages affected by this feature.
+   - The automated checks must verify:
+     - updated pages still return `200 OK`
+     - updated pages still return HTML content
+     - the home page includes `Loki`
+     - the home page renders markup produced by the shared card partial
+     - the repositories index still renders the empty state text when there are no repositories
+     - the repositories index still renders persisted repository data
+     - the repositories empty state renders markup produced by the shared alert partial
+     - each repository item renders markup produced by the shared card partial
+     - the rendered HTML for adopted pages includes these daisyUI class hooks:
+       - home page card uses class `card`
+       - repositories empty state uses class `alert`
+       - repository items use class `card`
+   - Add view specs for the shared partials that verify the required locals render the corresponding daisyUI root classes:
+     - button renders class `btn`
+     - alert renders class `alert`
+     - card renders class `card`
+   - The test suite must run under the existing Rails/RSpec setup without introducing a new test framework dependency.
+
+## States
+
+- Loading: not applicable. This feature is server-rendered and defines no client-side loading UI.
+- Success:
+  - the home page returns `200 OK` and renders the required heading, paragraph, and shared card markup
+  - the repositories index returns `200 OK` and renders either the empty state alert or repository cards
+- Empty:
+  - when there are zero repositories, the repositories index renders the text `No repositories yet` inside markup from the shared alert partial
+- Error handling:
+  - no custom application-level error UI is added in this feature
+  - unhandled controller/view exceptions remain default Rails behavior and are out of scope
+  - frontend package installation or asset build failures are not a user-facing state and are out of scope for acceptance
+
+## Acceptance Criteria
+
+1. daisyUI is integrated into the existing Tailwind-based frontend setup and its classes compile into the application stylesheet used by Rails views.
+2. The application uses exactly one default light daisyUI theme applied through the main layout.
+3. Shared partials exist at:
+   - `app/views/shared/ui/_alert.html.erb`
+   - `app/views/shared/ui/_card.html.erb`
+6. The alert partial accepts `message:` and `variant:` locals and renders class `alert`.
+7. The card partial accepts `title:` and `body:` locals and renders class `card`.
+8. The application layout is updated to use the styling system for the main page shell and applies the selected daisyUI theme at the layout level.
+9. The home page returns `200 OK`, returns HTML, includes one `h1` with text `Loki`, includes one paragraph with text `Git-native translation workspace system for YAML-based i18n.`, and renders one shared card with class `card`.
+10. `GET /repositories` still returns `200 OK` and an HTML response.
+11. When there are zero repositories, the repositories index includes `No repositories yet` and renders the empty state through the shared alert partial with class `alert`.
+12. When repositories exist, the repositories index displays `provider`, `namespace_path`, `name`, and `default_base_ref`, and each repository item renders through the shared card partial with class `card`.
+13. The implementation adds no new product routes, no new domain workflows, no theme toggle, and no new frontend framework beyond the minimal package/configuration required to load daisyUI.
+13. The implementation adds no new product routes, no new domain workflows, no theme toggle, and no new frontend framework beyond `daisyui` and the frontend package files required to load it.
+
+## Implementation Constraints
+
+- Use standard Rails conventions for assets, views, partials, and RSpec coverage.
+- Keep changes minimal, local, and easy to review.
+- Prefer configuration and partials over custom abstraction layers.
+- Do not introduce ViewComponent, Phlex, React, or any other new rendering framework.
+- Do not migrate application JavaScript away from Importmaps.
+- Do not add dark mode, multiple themes, or runtime theme switching in this feature.
+- Do not restyle unrelated future screens that do not yet exist.
+- Do not remove Tailwind utility usage entirely; direct utility classes may still be used in views where shared primitives do not fit.
+- Do not introduce new business/domain logic while applying the styling system.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "loki",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "loki",
+      "dependencies": {
+        "daisyui": "^5.3.0"
+      }
+    },
+    "node_modules/daisyui": {
+      "version": "5.5.19",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.19.tgz",
+      "integrity": "sha512-pbFAkl1VCEh/MPCeclKL61I/MqRIFFhNU7yiXoDDRapXN4/qNCoMxeCCswyxEEhqL5eiTTfwHvucFtOE71C9sA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "loki",
+  "private": true,
+  "dependencies": {
+    "daisyui": "^5.3.0"
+  }
+}

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -74,6 +74,19 @@ RSpec.describe Repository, type: :model do
     end
   end
 
+  describe "#qualified_name" do
+    it "joins namespace_path and name" do
+      repository = described_class.new(
+        provider: "github",
+        namespace_path: "acme/platform",
+        name: "loki",
+        default_base_ref: "main"
+      )
+
+      expect(repository.qualified_name).to eq("acme/platform/loki")
+    end
+  end
+
   describe "database constraints" do
     it "enforces unique provider, namespace_path, and name at the database level" do
       described_class.create!(

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe "Home", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(response.media_type).to eq("text/html")
+      document = Nokogiri::HTML5(response.body)
+
+      expect(document.css("h1").map(&:text)).to eq(["Loki"])
+      expect(response.body).to include("Git-native translation workspace system for YAML-based i18n.")
+      expect(response.body).to include("Styling system")
+      expect(response.body).to include("daisyUI primitives are available for shared UI elements.")
+      expect(document.at_css(".card")).to be_present
     end
   end
 end

--- a/spec/requests/repositories_spec.rb
+++ b/spec/requests/repositories_spec.rb
@@ -8,9 +8,10 @@ RSpec.describe "Repositories", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.media_type).to eq("text/html")
       expect(response.body).to include("No repositories yet")
+      expect(Nokogiri::HTML5(response.body).at_css(".alert")).to be_present
     end
 
-    it "renders persisted repository data including default_base_ref" do
+    it "renders repository cards with the full name and default_base_ref" do
       Repository.create!(
         provider: "github",
         namespace_path: "acme/platform",
@@ -27,8 +28,9 @@ RSpec.describe "Repositories", type: :request do
       get "/repositories"
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("github", "acme/platform", "loki", "main")
-      expect(response.body).to include("gitlab", "acme/tools", "atlas", "develop")
+      expect(response.body).to include("github", "acme/platform/loki", "main")
+      expect(response.body).to include("gitlab", "acme/tools/atlas", "develop")
+      expect(Nokogiri::HTML5(response.body).css(".card").count).to eq(2)
     end
 
     it "routes to repositories#index" do

--- a/spec/views/shared/ui/alert_spec.rb
+++ b/spec/views/shared/ui/alert_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "shared/ui/_alert.html.erb", type: :view do
+  it "renders the alert root class with the required locals" do
+    render partial: "shared/ui/alert", locals: { message: "No repositories yet", variant: :info }
+
+    expect(rendered).to include('class="alert alert-info"')
+    expect(rendered).to include("No repositories yet")
+  end
+end

--- a/spec/views/shared/ui/card_spec.rb
+++ b/spec/views/shared/ui/card_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "shared/ui/_card.html.erb", type: :view do
+  it "renders the card root class with the required locals and block content" do
+    render inline: <<~ERB
+      <%= render "shared/ui/card", title: "Styling system" do %>
+        Shared card body
+      <% end %>
+    ERB
+
+    expect(rendered).to include('class="card border border-base-300 bg-base-100 shadow-sm"')
+    expect(rendered).to include("Styling system")
+    expect(rendered).to include("Shared card body")
+  end
+end


### PR DESCRIPTION
## Summary
- add daisyUI to the Tailwind setup with a single default light theme
- add shared alert/card partials and apply them to the layout, home page, and repositories index
- add request, view, and model coverage plus the feature 003 memory-bank brief/spec/plan

## Verification
- bin/rspec spec/views/shared/ui spec/requests/home_spec.rb spec/requests/repositories_spec.rb spec/models/repository_spec.rb
- bin/rspec
- bundle exec rubocop --cache false

Closes #62